### PR TITLE
chore(): do not import typescript and eslint library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# neat-eslint
-Neat Group of rules to lint our typescript projects
+# Neat-eslint
+A neat group of rules for linting our TypeScript projects.
+
+## Installation
+
+### If it's only a TypeScript project.
+
+First, import dependencies:
+
+``` 
+yarn add
+    typescript-eslint
+    eslint
+    @types/eslint
+    @typescript-eslint/eslint-plugin
+    @typescript-eslint/parser
+    git+https://github.com/Neat-Pagos/neat-eslint.git#DEPLOY_vX.X.X
+```
+Or
+``` 
+npm install
+    typescript-eslint
+    eslint
+    @types/eslint
+    @typescript-eslint/eslint-plugin
+    @typescript-eslint/parser
+    git+https://github.com/Neat-Pagos/neat-eslint.git#DEPLOY_vX.X.X
+```
+
+Then, configure the eslintrc:
+
+```
+module.exports = {
+  'parser': '@typescript-eslint/parser',
+  root: true,
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'neat-eslint',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+  },
+  rules: {},
+};
+
+```
+
+And you'll have all the recommended rules in addition to Neat rules.
+
+### If you have another framework that already uses TypeScript ESLint
+
+For example, Vue already has a TypeScript ESLint version, but we want to add our Neat-eslint rules.
+
+Install Vue dependencies and Neat-eslint:
+
+
+``` 
+yarn add
+    eslint-plugin-vue
+    @vue/eslint-config-typescript
+    git+https://github.com/Neat-Pagos/neat-eslint.git#DEPLOY_vX.X.X
+```
+Or
+``` 
+npm install
+    eslint-plugin-vue
+    @vue/eslint-config-typescript
+    git+https://github.com/Neat-Pagos/neat-eslint.git#DEPLOY_vX.X.X
+```
+
+Then, configure the eslintrc:
+
+```
+module.exports = {
+  root: true,
+  extends: [
+    'plugin:vue/vue3-recommended',
+    '@vue/typescript/recommended',
+    '@vue/eslint-config-typescript',
+    'neat-eslint',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+  },
+  rules: {},
+};
+
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,6 @@
 "use strict";
 module.exports = {
-    'parser': '@typescript-eslint/parser',
     'extends': [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended',
         'plugin:import/recommended',
         'plugin:import/typescript'
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neat-eslint",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Neat Group of rules to lint our typescript projects",
   "main": "lib/index.js",
   "scripts": {
@@ -11,15 +11,15 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^5.3.3"
-  },
-  "dependencies": {
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^7.3.0",
+    "eslint": "^8.57.0",
     "@types/eslint": "^8.56.5",
     "@typescript-eslint/eslint-plugin": "^7.3.0",
-    "@typescript-eslint/parser": "^7.3.0",
-    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^7.3.0"
+  },
+  "dependencies": {
     "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-import": "^2.29.1",
-    "typescript-eslint": "^7.3.0"
+    "eslint-plugin-import": "^2.29.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,5 @@
 export = {
-  'parser': '@typescript-eslint/parser',
   'extends': [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
     'plugin:import/recommended',
     'plugin:import/typescript'
   ],


### PR DESCRIPTION
Before, this library used to bring dependencies for ESLint, TypeScript ESLint, and configured them. Now, it doesn't bring these dependencies so that it can be imported into projects that already use these libraries.






